### PR TITLE
Use PassthroughSubject

### DIFF
--- a/Sources/SimplePublisher/SimplePublisher.swift
+++ b/Sources/SimplePublisher/SimplePublisher.swift
@@ -2,13 +2,12 @@ import Foundation
 import Combine
 
 public protocol SimplePublisher: Publisher {
-    var coordinator: SimpleCoordinator<Output, Failure> { get }
+    var coordinator: PassthroughSubject<Output, Failure> { get }
 }
 
 extension SimplePublisher {
     public func receive<S>(subscriber: S)
         where S: Subscriber, Failure == S.Failure, Output == S.Input {
-
         coordinator.receive(subscriber: subscriber)
     }
 }


### PR DESCRIPTION
I had planned to make this change today, but the fact that it seems to ignore demand when it has multiple subscribers is problematic. I'm going to write more tests to test cancelling and other things to see where else things might diverge.