### PR TITLE
Fix broken early return

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: ci
 on: push
 jobs:
   test:
-    runs-on: macOS-10.14
+    runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Switch Xcode to 11.3
-        run: xcversion select 11.3
+      - name: Switch Xcode to 11.5
+        run: xcversion select 11.5
       - name: Resolve package dependencies
         run: swift package resolve
       - name: Test

--- a/Sources/SimplePublisher/SimpleSubject.swift
+++ b/Sources/SimplePublisher/SimpleSubject.swift
@@ -11,9 +11,8 @@ public class SimpleSubject<Output, Failure>: Publisher, Synchronized where Failu
     
     public func receive<S>(subscriber: S)
         where S: Subscriber, Failure == S.Failure, Output == S.Input {
-            sync {
-                guard isIncomplete else { return }
-            }
+            let isIncomplete = sync { return self.isIncomplete }
+            guard isIncomplete else { return }
             
             let subscription = SimpleSubscription(publisher: self, subscriber: subscriber)
             


### PR DESCRIPTION
This fixes a minor issue in which an early return wouldn't be respected. The rest of the `simple-publisher` looks good and seems to match or exceed the expectations set by https://forums.swift.org/t/thread-safety-for-combine-publishers/29491/11.